### PR TITLE
[plugin] add duplicate plugin

### DIFF
--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -42,3 +42,19 @@ censor:
         # allowed_chat_ids:
         #   - -1001234567890  # Official channel ID (negative for supergroups/channels)
         #   - -1000987654321  # Another allowed chat
+
+    # Duplicate plugin - detects and blocks repetitive messages from users
+    # This plugin tracks identical or very similar messages within a time window
+    # and blocks users who exceed the maximum duplicate threshold.
+    # Priority: 150 (runs after rate limit, keyword, and regex checks)
+    duplicate:
+      enabled: true
+      priority: 150
+      config:
+        # Maximum number of duplicate messages allowed before blocking
+        max_duplicates: 1
+
+        # Time window to consider messages as duplicates
+        # Messages sent within this timeframe are compared for similarity
+        # Supported formats: "30s", "5m", "1h", "24h"
+        window: "5m"

--- a/internal/censor/plugin/plugin.go
+++ b/internal/censor/plugin/plugin.go
@@ -46,4 +46,8 @@ type Plugin interface {
 	// Priority returns the execution priority (lower = earlier execution)
 	// Useful for short-circuiting expensive operations
 	Priority() int
+
+	// Cleanup performs maintenance tasks for the plugin.
+	// Called periodically to clean up expired entries.
+	Cleanup(ctx context.Context)
 }

--- a/internal/censor/plugin/plugin.go
+++ b/internal/censor/plugin/plugin.go
@@ -35,6 +35,12 @@ type Message struct {
 	ForwardedFromChatID *int64 // Chat ID where original message was sent (if forwarded)
 }
 
+// Metadata contains information about a plugin.
+type Metadata struct {
+	Name    string                                      // Plugin name
+	Factory func(params map[string]any) (Plugin, error) // Factory function
+}
+
 // Plugin is the interface that all censor plugins must implement.
 type Plugin interface {
 	// Name returns the unique identifier for this plugin

--- a/internal/censor/plugins/duplicate/config.go
+++ b/internal/censor/plugins/duplicate/config.go
@@ -1,0 +1,96 @@
+package duplicate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/capcom6/censor-tg-bot/internal/censor/plugin"
+)
+
+const (
+	// DefaultMaxDuplicates is the default maximum number of duplicate messages allowed before blocking.
+	DefaultMaxDuplicates = 1
+	// DefaultWindow is the default time window to consider messages as duplicates.
+	DefaultWindow = 5 * time.Minute
+	// MinWindow is the minimum reasonable window duration.
+	MinWindow = 10 * time.Second
+	// MaxWindow is the maximum reasonable window duration.
+	MaxWindow = 24 * time.Hour
+)
+
+// Config represents the configuration for the duplicate detection plugin.
+type Config struct {
+	MaxDuplicates int           // Maximum number of duplicate messages allowed before blocking
+	Window        time.Duration // Time window to consider messages as duplicates
+}
+
+// NewConfig creates a new configuration from the provided map.
+func NewConfig(config map[string]any) (Config, error) {
+	c := DefaultConfig()
+
+	// Parse MaxDuplicates
+	if maxDuplicates, ok := config["max_duplicates"]; ok {
+		if c.MaxDuplicates, ok = maxDuplicates.(int); !ok {
+			return Config{}, fmt.Errorf(
+				"%w: failed to parse max_duplicates: expected int, got %T",
+				plugin.ErrInvalidConfig,
+				maxDuplicates,
+			)
+		}
+	}
+
+	// Parse Window
+	if window, ok := config["window"]; ok {
+		str, windowStrOk := window.(string)
+		if !windowStrOk {
+			return Config{}, fmt.Errorf(
+				"%w: failed to parse window: expected string, got %T",
+				plugin.ErrInvalidConfig,
+				window,
+			)
+		}
+
+		var err error
+		if c.Window, err = time.ParseDuration(str); err != nil {
+			return Config{}, fmt.Errorf("%w: failed to parse window: %w", plugin.ErrInvalidConfig, err)
+		}
+	}
+
+	// Validate the configuration
+	if err := c.Validate(); err != nil {
+		return Config{}, fmt.Errorf("%w: %w", plugin.ErrInvalidConfig, err)
+	}
+
+	return c, nil
+}
+
+// DefaultConfig returns a configuration with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		MaxDuplicates: DefaultMaxDuplicates,
+		Window:        DefaultWindow,
+	}
+}
+
+// Validate checks if the configuration values are valid.
+func (c Config) Validate() error {
+	// Check MaxDuplicates
+	if c.MaxDuplicates <= 0 {
+		return fmt.Errorf(
+			"%w: max_duplicates must be greater than 0, got: %d",
+			plugin.ErrInvalidConfig,
+			c.MaxDuplicates,
+		)
+	}
+
+	// Check Window
+	if c.Window < MinWindow {
+		return fmt.Errorf("%w: window must be at least %s, got: %s", plugin.ErrInvalidConfig, MinWindow, c.Window)
+	}
+
+	if c.Window > MaxWindow {
+		return fmt.Errorf("%w: window must not exceed %s, got: %s", plugin.ErrInvalidConfig, MaxWindow, c.Window)
+	}
+
+	return nil
+}

--- a/internal/censor/plugins/duplicate/config.go
+++ b/internal/censor/plugins/duplicate/config.go
@@ -58,7 +58,7 @@ func NewConfig(config map[string]any) (Config, error) {
 
 	// Validate the configuration
 	if err := c.Validate(); err != nil {
-		return Config{}, fmt.Errorf("%w: %w", plugin.ErrInvalidConfig, err)
+		return Config{}, err
 	}
 
 	return c, nil
@@ -75,9 +75,9 @@ func DefaultConfig() Config {
 // Validate checks if the configuration values are valid.
 func (c Config) Validate() error {
 	// Check MaxDuplicates
-	if c.MaxDuplicates <= 0 {
+	if c.MaxDuplicates < 0 {
 		return fmt.Errorf(
-			"%w: max_duplicates must be greater than 0, got: %d",
+			"%w: max_duplicates must be >= 0, got: %d",
 			plugin.ErrInvalidConfig,
 			c.MaxDuplicates,
 		)

--- a/internal/censor/plugins/duplicate/config_test.go
+++ b/internal/censor/plugins/duplicate/config_test.go
@@ -1,0 +1,160 @@
+package duplicate_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/capcom6/censor-tg-bot/internal/censor/plugins/duplicate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_NewConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]any
+		want    duplicate.Config
+		wantErr bool
+	}{
+		{
+			name: "valid configuration with all fields",
+			config: map[string]any{
+				"max_duplicates": 5,
+				"window":         "10m",
+			},
+			want: duplicate.Config{
+				MaxDuplicates: 5,
+				Window:        10 * time.Minute,
+			},
+			wantErr: false,
+		},
+		{
+			name:   "valid configuration with defaults",
+			config: map[string]any{},
+			want: duplicate.Config{
+				MaxDuplicates: 1,
+				Window:        5 * time.Minute,
+				// default
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid max_duplicates type",
+			config: map[string]any{
+				"max_duplicates": "3",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid window type",
+			config: map[string]any{
+				"window": 300,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid window format",
+			config: map[string]any{
+				"window": "invalid",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := duplicate.NewConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConfig_DefaultConfig(t *testing.T) {
+	config := duplicate.DefaultConfig()
+
+	require.Equal(t, 1, config.MaxDuplicates)
+	require.Equal(t, 5*time.Minute, config.Window)
+
+	// Should be valid by default
+	require.NoError(t, config.Validate())
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  duplicate.Config
+		wantErr bool
+	}{
+		{
+			name: "valid configuration",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        5 * time.Minute,
+			},
+			wantErr: false,
+		},
+		{
+			name: "max_duplicates = 0",
+			config: duplicate.Config{
+				MaxDuplicates: 0,
+				Window:        5 * time.Minute,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative max_duplicates",
+			config: duplicate.Config{
+				MaxDuplicates: -1,
+				Window:        5 * time.Minute,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero window",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative window",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        -1 * time.Minute,
+			},
+			wantErr: true,
+		},
+		{
+			name: "window too small",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        5 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "window too large",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        48 * time.Hour,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/censor/plugins/duplicate/config_test.go
+++ b/internal/censor/plugins/duplicate/config_test.go
@@ -103,7 +103,7 @@ func TestConfig_Validate(t *testing.T) {
 				MaxDuplicates: 0,
 				Window:        5 * time.Minute,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "negative max_duplicates",

--- a/internal/censor/plugins/duplicate/duplicate.go
+++ b/internal/censor/plugins/duplicate/duplicate.go
@@ -1,0 +1,114 @@
+package duplicate
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"github.com/capcom6/censor-tg-bot/internal/censor/plugin"
+)
+
+const (
+	minTextLength = 3 // Minimum text length for duplicate detection
+)
+
+type Plugin struct {
+	storage *Storage
+	config  Config
+}
+
+func New(config Config) plugin.Plugin {
+	return &Plugin{
+		storage: NewStorage(config.Window),
+		config:  config,
+	}
+}
+
+func (p *Plugin) Name() string {
+	return "duplicate"
+}
+
+func (p *Plugin) Priority() int {
+	const priority = 150
+	return priority
+}
+
+func (p *Plugin) Evaluate(_ context.Context, msg plugin.Message) (plugin.Result, error) {
+	// Get the message text to analyze
+	text := p.getMessageText(msg)
+
+	// Skip empty or very short messages
+	if len(text) < minTextLength {
+		return plugin.Result{
+			Action:   plugin.ActionSkip,
+			Reason:   "message too short for duplicate detection",
+			Metadata: map[string]any{"text_length": len(text)},
+			Plugin:   p.Name(),
+		}, nil
+	}
+
+	// Generate message hash for duplicate detection
+	messageHash := p.generateMessageHash(text)
+
+	// Record duplicate and check if limit exceeded
+	stat := p.storage.Record(
+		msg.ChatID,
+		messageHash,
+	)
+
+	if stat.Count > p.config.MaxDuplicates {
+		return plugin.Result{
+			Action: plugin.ActionBlock,
+			Reason: fmt.Sprintf(
+				"duplicate messages exceeded limit (%d in %s)",
+				p.config.MaxDuplicates,
+				p.config.Window,
+			),
+			Metadata: map[string]any{
+				"count":          stat.Count,
+				"max_duplicates": p.config.MaxDuplicates,
+				"window":         p.config.Window.String(),
+				"message_hash":   messageHash,
+			},
+			Plugin: p.Name(),
+		}, nil
+	}
+
+	// Within limits, allow the message
+	return plugin.Result{
+		Action: plugin.ActionAllow,
+		Reason: "duplicate limit not exceeded",
+		Metadata: map[string]any{
+			"message_hash": messageHash,
+		},
+		Plugin: p.Name(),
+	}, nil
+}
+
+// getMessageText extracts the primary text content from a message.
+// Prefers Text over Caption, falling back to Caption if Text is empty.
+func (p *Plugin) getMessageText(msg plugin.Message) string {
+	text := strings.TrimSpace(msg.Text)
+	if text != "" {
+		return text
+	}
+
+	// Fallback to caption if text is empty
+	return strings.TrimSpace(msg.Caption)
+}
+
+// generateMessageHash creates a hash for duplicate detection.
+func (p *Plugin) generateMessageHash(text string) string {
+	// Generate hash based on text content
+	hasher := fnv.New32a()
+	hasher.Write([]byte(text))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// Cleanup performs maintenance tasks for the plugin.
+// Should be called periodically to clean up expired entries.
+func (p *Plugin) Cleanup(_ context.Context) {
+	p.storage.Cleanup()
+}

--- a/internal/censor/plugins/duplicate/duplicate_test.go
+++ b/internal/censor/plugins/duplicate/duplicate_test.go
@@ -133,10 +133,10 @@ func TestPlugin_Evaluate(t *testing.T) {
 				ChatID: 12345,
 			},
 			expectedAction: plugin.ActionBlock,
-			expectedReason: "duplicate messages exceeded limit (2 in 5m0s)",
+			expectedReason: "duplicate limit exceeded (4 occurrences, max 3 allowed in 5m0s)",
 			setup: func(p *duplicate.Plugin) {
-				// First two calls
-				for range 2 {
+				// First three calls
+				for range 3 {
 					_, err := p.Evaluate(context.Background(), plugin.Message{
 						Text:   "Duplicate message",
 						ChatID: 12345,
@@ -246,7 +246,7 @@ func TestStorage_WindowExpiration(t *testing.T) {
 
 func TestPlugin_UnicodeHandling(t *testing.T) {
 	config := duplicate.Config{
-		MaxDuplicates: 2,
+		MaxDuplicates: 1,
 		Window:        5 * time.Minute,
 	}
 
@@ -356,7 +356,7 @@ func TestPlugin_HashGeneration(t *testing.T) {
 	// Hash should be consistent and deterministic
 	require.Equal(
 		t,
-		"24fd8bad",
+		"95a0db0d",
 		result2.Metadata["message_hash"],
 	)
 }
@@ -374,14 +374,14 @@ func TestPlugin_Integration(t *testing.T) {
 		ChatID: 12345,
 	}
 
-	// First 3 messages should be allowed
-	for range 3 {
+	// First 4 messages should be allowed
+	for range 4 {
 		result, err := p.Evaluate(context.Background(), message)
 		require.NoError(t, err)
 		require.Equal(t, plugin.ActionAllow, result.Action)
 	}
 
-	// Fourth message should be blocked
+	// Fifth message should be blocked
 	result, err := p.Evaluate(context.Background(), message)
 	require.NoError(t, err)
 	require.Equal(t, plugin.ActionBlock, result.Action)

--- a/internal/censor/plugins/duplicate/duplicate_test.go
+++ b/internal/censor/plugins/duplicate/duplicate_test.go
@@ -1,0 +1,527 @@
+package duplicate_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/capcom6/censor-tg-bot/internal/censor/plugin"
+	"github.com/capcom6/censor-tg-bot/internal/censor/plugins/duplicate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlugin_New(t *testing.T) {
+	config := duplicate.Config{
+		MaxDuplicates: 3,
+		Window:        5 * time.Minute,
+	}
+
+	p := duplicate.New(config)
+
+	require.NotNil(t, p)
+	require.Implements(t, (*plugin.Plugin)(nil), p)
+}
+
+func TestPlugin_Name(t *testing.T) {
+	config := duplicate.DefaultConfig()
+
+	p := duplicate.New(config)
+
+	require.Equal(t, "duplicate", p.Name())
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	config := duplicate.DefaultConfig()
+
+	p := duplicate.New(config)
+
+	require.Equal(t, 150, p.Priority())
+}
+
+func TestPlugin_Evaluate(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         duplicate.Config
+		message        plugin.Message
+		expectedAction plugin.Action
+		expectedReason string
+		setup          func(*duplicate.Plugin)
+	}{
+		{
+			name: "short message should skip",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Text:   "Hi",
+				ChatID: 12345,
+			},
+			expectedAction: plugin.ActionSkip,
+			expectedReason: "message too short for duplicate detection",
+		},
+		{
+			name: "empty text should skip",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Text:   "",
+				ChatID: 12345,
+			},
+			expectedAction: plugin.ActionSkip,
+			expectedReason: "message too short for duplicate detection",
+		},
+		{
+			name: "whitespace only should skip",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Text:   "   ",
+				ChatID: 12345,
+			},
+			expectedAction: plugin.ActionSkip,
+			expectedReason: "message too short for duplicate detection",
+		},
+		{
+			name: "first occurrence should allow",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Text:   "Hello world, this is a test message",
+				ChatID: 12345,
+			},
+			expectedAction: plugin.ActionAllow,
+			expectedReason: "duplicate limit not exceeded",
+		},
+		{
+			name: "second occurrence should allow",
+			config: duplicate.Config{
+				MaxDuplicates: 3,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Text:   "Hello world, this is a test message",
+				ChatID: 12345,
+			},
+			expectedAction: plugin.ActionAllow,
+			expectedReason: "duplicate limit not exceeded",
+			setup: func(p *duplicate.Plugin) {
+				// First call
+				_, err := p.Evaluate(context.Background(), plugin.Message{
+					Text:   "Hello world, this is a test message",
+					ChatID: 12345,
+				})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "duplicate limit exceeded should block",
+			config: duplicate.Config{
+				MaxDuplicates: 2,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Text:   "Duplicate message",
+				ChatID: 12345,
+			},
+			expectedAction: plugin.ActionBlock,
+			expectedReason: "duplicate messages exceeded limit (2 in 5m0s)",
+			setup: func(p *duplicate.Plugin) {
+				// First two calls
+				for range 2 {
+					_, err := p.Evaluate(context.Background(), plugin.Message{
+						Text:   "Duplicate message",
+						ChatID: 12345,
+					})
+					require.NoError(t, err)
+				}
+			},
+		},
+		{
+			name: "different chat IDs should not interfere",
+			config: duplicate.Config{
+				MaxDuplicates: 2,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Text:   "Same message",
+				ChatID: 99999,
+			},
+			expectedAction: plugin.ActionAllow,
+			expectedReason: "duplicate limit not exceeded",
+		},
+		{
+			name: "caption should work like text",
+			config: duplicate.Config{
+				MaxDuplicates: 2,
+				Window:        5 * time.Minute,
+			},
+			message: plugin.Message{
+				Caption: "Caption message",
+				ChatID:  12345,
+			},
+			expectedAction: plugin.ActionAllow,
+			expectedReason: "duplicate limit not exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := duplicate.New(tt.config)
+
+			// Call setup function if provided
+			if tt.setup != nil {
+				if dupPlugin, ok := p.(*duplicate.Plugin); ok {
+					tt.setup(dupPlugin)
+				}
+			}
+
+			result, err := p.Evaluate(context.Background(), tt.message)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedAction, result.Action)
+			require.Equal(t, tt.expectedReason, result.Reason)
+			require.Equal(t, "duplicate", result.Plugin)
+		})
+	}
+}
+
+func TestStorage_RecordDuplicate(t *testing.T) {
+	storage := duplicate.NewStorage(5 * time.Minute)
+
+	// First occurrence - should return 1 (not exceeded)
+	stat := storage.Record(12345, "hash1")
+	require.Equal(t, 1, stat.Count)
+
+	// Second occurrence - should return 2 (not exceeded)
+	stat = storage.Record(12345, "hash1")
+	require.Equal(t, 2, stat.Count)
+
+	// Third occurrence - should return 3 (exceeded)
+	stat = storage.Record(12345, "hash1")
+	require.Equal(t, 3, stat.Count)
+
+	// Different chat ID - should return 1 (separate tracking)
+	stat = storage.Record(99999, "hash1")
+	require.Equal(t, 1, stat.Count)
+
+	// Different hash - should return 1
+	stat = storage.Record(12345, "hash2")
+	require.Equal(t, 1, stat.Count)
+}
+
+func TestStorage_WindowExpiration(t *testing.T) {
+	storage := duplicate.NewStorage(1 * time.Second)
+
+	// Record a duplicate
+	stat := storage.Record(12345, "hash1")
+	require.Equal(t, 1, stat.Count)
+
+	// Second occurrence within window
+	stat = storage.Record(12345, "hash1")
+	require.Equal(t, 2, stat.Count)
+
+	// Wait for window to expire
+	time.Sleep(2 * time.Second)
+
+	// Should reset count after window expiration
+	stat = storage.Record(12345, "hash1")
+	require.Equal(t, 1, stat.Count)
+
+	// Should still allow another within the new window
+	stat = storage.Record(12345, "hash1")
+	require.Equal(t, 2, stat.Count)
+
+	// Third occurrence should now exceed
+	stat = storage.Record(12345, "hash1")
+	require.Equal(t, 3, stat.Count)
+}
+
+func TestPlugin_UnicodeHandling(t *testing.T) {
+	config := duplicate.Config{
+		MaxDuplicates: 2,
+		Window:        5 * time.Minute,
+	}
+
+	p := duplicate.New(config)
+
+	unicodeMessage := plugin.Message{
+		Text:   "Привет мир! Hello 世界! 🎉",
+		ChatID: 12345,
+	}
+
+	// First occurrence
+	result1, err := p.Evaluate(context.Background(), unicodeMessage)
+	require.NoError(t, err)
+	require.Equal(t, plugin.ActionAllow, result1.Action)
+
+	// Second occurrence
+	result2, err := p.Evaluate(context.Background(), unicodeMessage)
+	require.NoError(t, err)
+	require.Equal(t, plugin.ActionAllow, result2.Action)
+
+	// Third occurrence - should block
+	result3, err := p.Evaluate(context.Background(), unicodeMessage)
+	require.NoError(t, err)
+	require.Equal(t, plugin.ActionBlock, result3.Action)
+}
+
+func TestPlugin_TextExtraction(t *testing.T) {
+	config := duplicate.Config{
+		MaxDuplicates: 2,
+		Window:        5 * time.Minute,
+	}
+
+	tests := []struct {
+		name           string
+		message        plugin.Message
+		expectedAction plugin.Action
+	}{
+		{
+			name: "text takes precedence over caption",
+			message: plugin.Message{
+				Text:    "This is text",
+				Caption: "This is caption",
+				ChatID:  12345,
+			},
+			expectedAction: plugin.ActionAllow,
+		},
+		{
+			name: "caption used when text is empty",
+			message: plugin.Message{
+				Text:    "",
+				Caption: "This is caption",
+				ChatID:  12345,
+			},
+			expectedAction: plugin.ActionAllow,
+		},
+		{
+			name: "whitespace in text trimmed",
+			message: plugin.Message{
+				Text:    "  message  ",
+				Caption: "caption",
+				ChatID:  12345,
+			},
+			expectedAction: plugin.ActionAllow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := duplicate.New(config)
+
+			result, err := p.Evaluate(context.Background(), tt.message)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedAction, result.Action)
+		})
+	}
+}
+
+func TestPlugin_HashGeneration(t *testing.T) {
+	config := duplicate.Config{
+		MaxDuplicates: 3,
+		Window:        5 * time.Minute,
+	}
+
+	p := duplicate.New(config)
+
+	// Test SHA-256 hash generation
+	message := "Test message for hashing"
+
+	// The hash should be consistent
+	result1, err := p.Evaluate(context.Background(), plugin.Message{
+		Text:   message,
+		ChatID: 12345,
+	})
+	require.NoError(t, err)
+
+	// Verify the metadata contains the hash
+	require.NotEmpty(t, result1.Metadata["message_hash"])
+
+	p2 := duplicate.New(config)
+
+	result2, err := p2.Evaluate(context.Background(), plugin.Message{
+		Text:   message,
+		ChatID: 12345,
+	})
+	require.NoError(t, err)
+
+	// Hash should be consistent and deterministic
+	require.Equal(
+		t,
+		"4a96a9be99b7a5eb93f75dc7fcee805d88841c76706ad1fde745ae7a9cf7233d",
+		result2.Metadata["message_hash"],
+	)
+}
+
+func TestPlugin_Integration(t *testing.T) {
+	config := duplicate.Config{
+		MaxDuplicates: 3,
+		Window:        1 * time.Second,
+	}
+
+	p := duplicate.New(config)
+
+	message := plugin.Message{
+		Text:   "Integration test message",
+		ChatID: 12345,
+	}
+
+	// First 3 messages should be allowed
+	for range 3 {
+		result, err := p.Evaluate(context.Background(), message)
+		require.NoError(t, err)
+		require.Equal(t, plugin.ActionAllow, result.Action)
+	}
+
+	// Fourth message should be blocked
+	result, err := p.Evaluate(context.Background(), message)
+	require.NoError(t, err)
+	require.Equal(t, plugin.ActionBlock, result.Action)
+
+	// Wait for window to expire
+	time.Sleep(2 * time.Second)
+
+	// Should allow again after window expires
+	result, err = p.Evaluate(context.Background(), message)
+	require.NoError(t, err)
+	require.Equal(t, plugin.ActionAllow, result.Action)
+}
+
+func TestPlugin_NilConfig(t *testing.T) {
+	// This should work with default configuration
+	p := duplicate.New(duplicate.Config{})
+	require.NotNil(t, p)
+
+	// But the default config should be invalid
+	config := duplicate.Config{}
+	require.Error(t, config.Validate())
+
+	// Test that the plugin can still be created and responds appropriately
+	// Use a short message (<3 chars) to get ActionSkip
+	message := plugin.Message{Text: "Hi", ChatID: 12345}
+	result, err := p.Evaluate(context.Background(), message)
+	require.NoError(t, err)
+	require.Equal(t, plugin.ActionSkip, result.Action) // Should skip due to short text
+}
+
+func TestPlugin_EmptyMessageHandling(t *testing.T) {
+	config := duplicate.Config{
+		MaxDuplicates: 3,
+		Window:        5 * time.Minute,
+	}
+
+	testCases := []struct {
+		name    string
+		message plugin.Message
+		reason  string
+	}{
+		{
+			name: "empty string",
+			message: plugin.Message{
+				Text:   "",
+				ChatID: 12345,
+			},
+			reason: "message too short for duplicate detection",
+		},
+		{
+			name: "only spaces",
+			message: plugin.Message{
+				Text:   "   ",
+				ChatID: 12345,
+			},
+			reason: "message too short for duplicate detection",
+		},
+		{
+			name: "only newlines",
+			message: plugin.Message{
+				Text:   "\n\n\n",
+				ChatID: 12345,
+			},
+			reason: "message too short for duplicate detection",
+		},
+		{
+			name: "single character",
+			message: plugin.Message{
+				Text:   "a",
+				ChatID: 12345,
+			},
+			reason: "message too short for duplicate detection",
+		},
+		{
+			name: "two characters",
+			message: plugin.Message{
+				Text:   "ab",
+				ChatID: 12345,
+			},
+			reason: "message too short for duplicate detection",
+		},
+		{
+			name: "three characters minimum",
+			message: plugin.Message{
+				Text:   "abcd", // Use 4 characters to ensure it's processed
+				ChatID: 12345,
+			},
+			reason: "duplicate limit not exceeded",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			p := duplicate.New(config)
+
+			result, err := p.Evaluate(context.Background(), tt.message)
+			require.NoError(t, err)
+
+			// Determine expected action based on the reason
+			var expectedAction plugin.Action
+			if strings.Contains(tt.reason, "too short") {
+				expectedAction = plugin.ActionSkip
+			} else {
+				expectedAction = plugin.ActionAllow
+			}
+
+			require.Equal(t, expectedAction, result.Action)
+			require.Equal(t, tt.reason, result.Reason)
+		})
+	}
+}
+
+// Benchmark tests for performance testing.
+func BenchmarkPlugin_Evaluate(b *testing.B) {
+	config := duplicate.Config{
+		MaxDuplicates: 3,
+		Window:        5 * time.Minute,
+	}
+
+	p := duplicate.New(config)
+
+	message := plugin.Message{
+		Text:   "This is a benchmark test message with enough length",
+		ChatID: 12345,
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := p.Evaluate(context.Background(), message)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStorage_RecordDuplicate(b *testing.B) {
+	storage := duplicate.NewStorage(5 * time.Minute)
+
+	b.ResetTimer()
+	for i := range b.N {
+		storage.Record(12345, fmt.Sprintf("hash-%d", i))
+	}
+}

--- a/internal/censor/plugins/duplicate/duplicate_test.go
+++ b/internal/censor/plugins/duplicate/duplicate_test.go
@@ -356,7 +356,7 @@ func TestPlugin_HashGeneration(t *testing.T) {
 	// Hash should be consistent and deterministic
 	require.Equal(
 		t,
-		"4a96a9be99b7a5eb93f75dc7fcee805d88841c76706ad1fde745ae7a9cf7233d",
+		"24fd8bad",
 		result2.Metadata["message_hash"],
 	)
 }

--- a/internal/censor/plugins/duplicate/storage.go
+++ b/internal/censor/plugins/duplicate/storage.go
@@ -1,0 +1,85 @@
+package duplicate
+
+import (
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Storage implements thread-safe duplicate detection storage.
+type Storage struct {
+	window  time.Duration
+	entries map[string]*Entry // Key format: "chatID:messageHash"
+	mu      sync.Mutex
+}
+
+// Entry represents a duplicate tracking entry.
+type Entry struct {
+	Count     int       // Number of duplicate messages seen
+	FirstSeen time.Time // Timestamp of first occurrence
+	LastSeen  time.Time // Timestamp of most recent occurrence
+}
+
+// NewStorage creates a new Storage instance.
+func NewStorage(window time.Duration) *Storage {
+	return &Storage{
+		window:  window,
+		entries: make(map[string]*Entry),
+		mu:      sync.Mutex{},
+	}
+}
+
+// generateKey creates a unique key from chatID and messageHash.
+func generateKey(chatID int64, messageHash string) string {
+	return strconv.FormatInt(chatID, 10) + ":" + messageHash
+}
+
+// Record records a duplicate message and returns the current entry state.
+func (s *Storage) Record(chatID int64, messageHash string) Entry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	key := generateKey(chatID, messageHash)
+	entry, exists := s.entries[key]
+
+	if !exists {
+		// Create new entry
+		entry = &Entry{
+			Count:     1,
+			FirstSeen: now,
+			LastSeen:  now,
+		}
+		s.entries[key] = entry
+		return *entry
+	}
+
+	// Check if the entry has expired
+	if now.Sub(entry.FirstSeen) > s.window {
+		// Reset entry as it's outside the window
+		entry.Count = 1
+		entry.FirstSeen = now
+		entry.LastSeen = now
+		return *entry
+	}
+
+	// Increment existing entry
+	entry.Count++
+	entry.LastSeen = now
+
+	// Return current entry for limit check by caller
+	return *entry
+}
+
+// Cleanup removes entries that are older than the specified window.
+func (s *Storage) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range s.entries {
+		if now.Sub(entry.FirstSeen) > s.window {
+			delete(s.entries, key)
+		}
+	}
+}

--- a/internal/censor/plugins/forwarded/forwarded.go
+++ b/internal/censor/plugins/forwarded/forwarded.go
@@ -7,6 +7,20 @@ import (
 	"github.com/samber/lo"
 )
 
+func Metadata() plugin.Metadata {
+	return plugin.Metadata{
+		Name: "forwarded",
+		Factory: func(params map[string]any) (plugin.Plugin, error) {
+			config, err := NewConfig(params)
+			if err != nil {
+				return nil, err
+			}
+
+			return New(config), nil
+		},
+	}
+}
+
 type Plugin struct {
 	config Config
 }
@@ -78,6 +92,6 @@ func (p *Plugin) Evaluate(_ context.Context, msg plugin.Message) (plugin.Result,
 }
 
 // Cleanup implements plugin.Plugin.
-func (p *Plugin) Cleanup() {
+func (p *Plugin) Cleanup(_ context.Context) {
 	// no-op
 }

--- a/internal/censor/plugins/forwarded/forwarded.go
+++ b/internal/censor/plugins/forwarded/forwarded.go
@@ -77,4 +77,7 @@ func (p *Plugin) Evaluate(_ context.Context, msg plugin.Message) (plugin.Result,
 	}, nil
 }
 
-var _ plugin.Plugin = (*Plugin)(nil)
+// Cleanup implements plugin.Plugin.
+func (p *Plugin) Cleanup() {
+	// no-op
+}

--- a/internal/censor/plugins/keyword/keyword.go
+++ b/internal/censor/plugins/keyword/keyword.go
@@ -71,6 +71,11 @@ func (p *Plugin) Evaluate(_ context.Context, msg plugin.Message) (plugin.Result,
 	}, nil
 }
 
+// Cleanup implements plugin.Plugin.
+func (p *Plugin) Cleanup(_ context.Context) {
+	// no-op
+}
+
 func (p *Plugin) normalizeText(text string) string {
 	if text == "" {
 		return ""
@@ -78,5 +83,3 @@ func (p *Plugin) normalizeText(text string) string {
 	text = p.filter.ReplaceAllString(text, "")
 	return strings.ToLower(text)
 }
-
-var _ plugin.Plugin = (*Plugin)(nil)

--- a/internal/censor/plugins/keyword/keyword.go
+++ b/internal/censor/plugins/keyword/keyword.go
@@ -9,6 +9,20 @@ import (
 	"github.com/samber/lo"
 )
 
+func Metadata() plugin.Metadata {
+	return plugin.Metadata{
+		Name: "keyword",
+		Factory: func(params map[string]any) (plugin.Plugin, error) {
+			config, err := NewConfig(params)
+			if err != nil {
+				return nil, err
+			}
+
+			return New(config), nil
+		},
+	}
+}
+
 type Plugin struct {
 	blacklist []string
 	filter    *regexp.Regexp

--- a/internal/censor/plugins/module.go
+++ b/internal/censor/plugins/module.go
@@ -15,11 +15,11 @@ func Module() fx.Option {
 		"plugins",
 		logger.WithNamedLogger("plugins"),
 		fx.Provide(
-			fx.Annotate(keyword.New, fx.ResultTags(`group:"plugins"`)),
-			fx.Annotate(ratelimit.New, fx.ResultTags(`group:"plugins"`)),
-			fx.Annotate(regex.New, fx.ResultTags(`group:"plugins"`)),
-			fx.Annotate(forwarded.New, fx.ResultTags(`group:"plugins"`)),
-			fx.Annotate(duplicate.New, fx.ResultTags(`group:"plugins"`)),
+			fx.Annotate(keyword.Metadata, fx.ResultTags(`group:"metadata"`)),
+			fx.Annotate(ratelimit.Metadata, fx.ResultTags(`group:"metadata"`)),
+			fx.Annotate(regex.Metadata, fx.ResultTags(`group:"metadata"`)),
+			fx.Annotate(forwarded.Metadata, fx.ResultTags(`group:"metadata"`)),
+			fx.Annotate(duplicate.Metadata, fx.ResultTags(`group:"metadata"`)),
 		),
 	)
 }

--- a/internal/censor/plugins/module.go
+++ b/internal/censor/plugins/module.go
@@ -1,9 +1,7 @@
 package plugins
 
 import (
-	"context"
-	"time"
-
+	"github.com/capcom6/censor-tg-bot/internal/censor/plugins/duplicate"
 	"github.com/capcom6/censor-tg-bot/internal/censor/plugins/forwarded"
 	"github.com/capcom6/censor-tg-bot/internal/censor/plugins/keyword"
 	"github.com/capcom6/censor-tg-bot/internal/censor/plugins/ratelimit"
@@ -17,38 +15,11 @@ func Module() fx.Option {
 		"plugins",
 		logger.WithNamedLogger("plugins"),
 		fx.Provide(
-			ratelimit.NewStorage,
-			fx.Private,
-		),
-		fx.Provide(
 			fx.Annotate(keyword.New, fx.ResultTags(`group:"plugins"`)),
 			fx.Annotate(ratelimit.New, fx.ResultTags(`group:"plugins"`)),
 			fx.Annotate(regex.New, fx.ResultTags(`group:"plugins"`)),
 			fx.Annotate(forwarded.New, fx.ResultTags(`group:"plugins"`)),
+			fx.Annotate(duplicate.New, fx.ResultTags(`group:"plugins"`)),
 		),
-		fx.Invoke(func(storage *ratelimit.Storage, lc fx.Lifecycle) {
-			ctx, cancel := context.WithCancel(context.Background())
-			lc.Append(fx.Hook{
-				OnStart: func(_ context.Context) error {
-					go func() {
-						ticker := time.NewTicker(1 * time.Minute)
-						defer ticker.Stop()
-						for {
-							select {
-							case <-ticker.C:
-								storage.Cleanup()
-							case <-ctx.Done():
-								return
-							}
-						}
-					}()
-					return nil
-				},
-				OnStop: func(_ context.Context) error {
-					cancel()
-					return nil
-				},
-			})
-		}),
 	)
 }

--- a/internal/censor/plugins/ratelimit/ratelimit.go
+++ b/internal/censor/plugins/ratelimit/ratelimit.go
@@ -7,6 +7,20 @@ import (
 	"github.com/capcom6/censor-tg-bot/internal/censor/plugin"
 )
 
+func Metadata() plugin.Metadata {
+	return plugin.Metadata{
+		Name: "ratelimit",
+		Factory: func(params map[string]any) (plugin.Plugin, error) {
+			config, err := NewConfig(params)
+			if err != nil {
+				return nil, err
+			}
+
+			return New(config), nil
+		},
+	}
+}
+
 type Plugin struct {
 	maxMessages int
 	window      time.Duration

--- a/internal/censor/plugins/ratelimit/ratelimit.go
+++ b/internal/censor/plugins/ratelimit/ratelimit.go
@@ -13,11 +13,11 @@ type Plugin struct {
 	storage     *Storage
 }
 
-func New(config Config, storage *Storage) plugin.Plugin {
+func New(config Config) plugin.Plugin {
 	return &Plugin{
 		maxMessages: config.MaxMessages,
 		window:      config.Window,
-		storage:     storage,
+		storage:     NewStorage(),
 	}
 }
 
@@ -54,4 +54,9 @@ func (p *Plugin) Evaluate(_ context.Context, msg plugin.Message) (plugin.Result,
 		Metadata: nil,
 		Plugin:   p.Name(),
 	}, nil
+}
+
+// Cleanup implements plugin.Plugin.
+func (p *Plugin) Cleanup(_ context.Context) {
+	p.storage.Cleanup()
 }

--- a/internal/censor/plugins/regex/regex.go
+++ b/internal/censor/plugins/regex/regex.go
@@ -7,6 +7,20 @@ import (
 	"github.com/capcom6/censor-tg-bot/internal/censor/plugin"
 )
 
+func Metadata() plugin.Metadata {
+	return plugin.Metadata{
+		Name: "regex",
+		Factory: func(params map[string]any) (plugin.Plugin, error) {
+			config, err := NewConfig(params)
+			if err != nil {
+				return nil, err
+			}
+
+			return New(config)
+		},
+	}
+}
+
 type Plugin struct {
 	patterns []*regexp.Regexp
 }

--- a/internal/censor/plugins/regex/regex.go
+++ b/internal/censor/plugins/regex/regex.go
@@ -61,3 +61,8 @@ func (p *Plugin) Evaluate(_ context.Context, msg plugin.Message) (plugin.Result,
 		Plugin:   p.Name(),
 	}, nil
 }
+
+// Cleanup implements plugin.Plugin.
+func (p *Plugin) Cleanup(_ context.Context) {
+	// no-op
+}

--- a/internal/censor/service.go
+++ b/internal/censor/service.go
@@ -145,6 +145,15 @@ func (s *Service) Evaluate(ctx context.Context, msg plugin.Message) plugin.Resul
 	return result
 }
 
+func (s *Service) Cleanup(ctx context.Context) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, p := range s.plugins {
+		p.Cleanup(ctx)
+	}
+}
+
 // getPluginPriority returns the priority of a plugin.
 func (s *Service) getPluginPriority(p plugin.Plugin) int {
 	if c, ok := s.config.Plugins[p.Name()]; ok {

--- a/internal/censor/service.go
+++ b/internal/censor/service.go
@@ -147,9 +147,11 @@ func (s *Service) Evaluate(ctx context.Context, msg plugin.Message) plugin.Resul
 
 func (s *Service) Cleanup(ctx context.Context) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	plugins := make([]plugin.Plugin, len(s.plugins))
+	copy(plugins, s.plugins)
+	s.mu.RUnlock()
 
-	for _, p := range s.plugins {
+	for _, p := range plugins {
 		p.Cleanup(ctx)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate-message detection: blocks messages exceeding a configurable threshold (default: 1 duplicate within 5m). Runs after rate-limit, keyword, and regex checks.

* **Reliability**
  * Plugins now expose cleanup hooks; the service invokes them for orderly shutdown and periodic cleanup.

* **Tests**
  * Extensive unit, integration and benchmark coverage for detection logic, config validation, storage/window semantics, and edge cases.

* **Documentation**
  * Example configuration updated to include the duplicate plugin and defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->