### PR TITLE
[plugins] add cache to LLM plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ forwarded:
 ### LLM Plugin
 Blocks messages containing potentially inappropriate content, spam, or violations by analyzing the message with an external large language model (LLM) API.
 
+Includes an optional caching feature to reduce LLM API call volume, lower operational costs, and improve response times by storing valid responses for repeated messages (LRU eviction triggers when cache_max_size is exceeded).
+
 **Configuration:**
 ```yaml
 llm:
@@ -194,6 +196,9 @@ llm:
     timeout: 30s              # API call timeout
     prompt: "Analyze the following message for inappropriate content, spam, or violations. Respond with JSON: {\"inappropriate\": boolean, \"confidence\": float, \"reason\": string}"
     temperature: 0.1          # Temperature for LLM sampling
+    cache_enabled: true       # Toggle cache functionality (default: true)
+    cache_ttl: "1h"           # Cache entry TTL (valid range: 1m-24h, default: 1h)
+    cache_max_size: 1000      # Max cached entries (triggers LRU eviction, default: 1000)
 ```
 
 **Use Cases:**

--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -71,3 +71,9 @@ censor:
         timeout: 30s
         prompt: 'Analyze the following message for inappropriate content, spam, or violations. Respond with JSON: {"inappropriate": boolean, "confidence": float, "reason": string}'
         temperature: 0.1
+        # Enable caching for LLM responses to reduce API calls and improve performance
+        cache_enabled: true # default: true
+        # Time to live for cached responses (supported formats: "30s", "5m", "1h")
+        cache_ttl: "1h" # default: "1h"
+        # Maximum number of responses to cache
+        cache_max_size: 1000 # default: 1000

--- a/internal/censor/plugins/llm/config_test.go
+++ b/internal/censor/plugins/llm/config_test.go
@@ -29,6 +29,10 @@ func TestNewConfig(t *testing.T) {
 				ConfidenceThreshold: llm.DefaultConfidenceThreshold,
 				Timeout:             llm.DefaultTimeout,
 				Temperature:         llm.DefaultTemperature,
+
+				CacheTTL:     llm.DefaultCacheTTL,
+				CacheMaxSize: llm.DefaultCacheMaxSize,
+				CacheEnabled: true,
 			},
 			wantErr: false,
 		},
@@ -49,6 +53,10 @@ func TestNewConfig(t *testing.T) {
 				Timeout:             45 * time.Second,
 				Prompt:              "Custom prompt",
 				Temperature:         0.7,
+
+				CacheTTL:     llm.DefaultCacheTTL,
+				CacheMaxSize: llm.DefaultCacheMaxSize,
+				CacheEnabled: true,
 			},
 			wantErr: false,
 		},

--- a/internal/censor/plugins/llm/storage.go
+++ b/internal/censor/plugins/llm/storage.go
@@ -1,0 +1,129 @@
+package llm
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// Storage implements an in-memory cache for LLM responses
+// Uses content-based hashing with TTL expiration and LRU eviction.
+type Storage struct {
+	ttl     time.Duration
+	maxSize int
+	entries map[string]*CachedResponse
+	mu      sync.Mutex
+}
+
+// CachedResponse represents a cached LLM response with metadata
+// Includes access tracking for LRU eviction.
+type CachedResponse struct {
+	Response    *Response
+	CachedAt    time.Time
+	AccessCount int
+	LastAccess  time.Time
+}
+
+// NewStorage creates a new cache storage with specified TTL and maximum size.
+func NewStorage(ttl time.Duration, maxSize int) *Storage {
+	return &Storage{
+		ttl:     ttl,
+		maxSize: maxSize,
+		entries: make(map[string]*CachedResponse),
+		mu:      sync.Mutex{},
+	}
+}
+
+// generateCacheKey creates a stable hash key from message text, model, and prompt
+// This ensures identical content with same configuration gets cache hits.
+func (s *Storage) generateCacheKey(text string, model string, prompt string) string {
+	// Include text, model, and prompt in hash to ensure cache validity
+	data := text + "\x00" + model + "\x00" + prompt
+	hash := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(hash[:])
+}
+
+// Get retrieves cached response if valid and not expired
+// Returns the response and a boolean indicating if cache hit occurred.
+func (s *Storage) Get(key string) (*Response, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, exists := s.entries[key]
+	if !exists {
+		return nil, false
+	}
+
+	// Check expiration
+	if time.Since(entry.CachedAt) > s.ttl {
+		delete(s.entries, key)
+		return nil, false
+	}
+
+	// Update access metadata
+	entry.AccessCount++
+	entry.LastAccess = time.Now()
+
+	return entry.Response, true
+}
+
+func (s *Storage) GetBy(text, model, prompt string) (*Response, bool) {
+	key := s.generateCacheKey(text, model, prompt)
+	return s.Get(key)
+}
+
+// Set stores a response in cache with LRU eviction if needed.
+func (s *Storage) Set(key string, resp *Response) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Evict if at capacity and key doesn't already exist
+	if _, exists := s.entries[key]; !exists && len(s.entries) >= s.maxSize {
+		s.evictLRU()
+	}
+
+	s.entries[key] = &CachedResponse{
+		Response:    resp,
+		CachedAt:    time.Now(),
+		AccessCount: 1,
+		LastAccess:  time.Now(),
+	}
+}
+
+func (s *Storage) SetBy(text, model, prompt string, resp *Response) {
+	key := s.generateCacheKey(text, model, prompt)
+	s.Set(key, resp)
+}
+
+// evictLRU removes the least recently used entry
+// Used when cache reaches maximum size.
+func (s *Storage) evictLRU() {
+	var oldestKey string
+	var oldestTime time.Time
+
+	for key, entry := range s.entries {
+		if oldestKey == "" || entry.LastAccess.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = entry.LastAccess
+		}
+	}
+
+	if oldestKey != "" {
+		delete(s.entries, oldestKey)
+	}
+}
+
+// Cleanup removes all expired entries from cache
+// Called periodically to maintain cache health.
+func (s *Storage) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range s.entries {
+		if now.Sub(entry.CachedAt) > s.ttl {
+			delete(s.entries, key)
+		}
+	}
+}

--- a/internal/censor/plugins/llm/storage_test.go
+++ b/internal/censor/plugins/llm/storage_test.go
@@ -1,0 +1,265 @@
+package llm_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/capcom6/censor-tg-bot/internal/censor/plugins/llm"
+)
+
+func TestStorage_GetSet(t *testing.T) {
+	// Create a new storage with 10s TTL and max size of 10
+	storage := llm.NewStorage(10*time.Second, 10)
+
+	// Test cache miss
+	key := "test-key"
+	response := &llm.Response{
+		Inappropriate: true,
+		Confidence:    0.9,
+		Reason:        "test reason",
+	}
+
+	// Get non-existent key
+	cachedResp, found := storage.Get(key)
+	if found {
+		t.Errorf("Expected cache miss, got cache hit")
+	}
+	if cachedResp != nil {
+		t.Errorf("Expected nil response, got %v", cachedResp)
+	}
+
+	// Set a response
+	storage.Set(key, response)
+
+	// Get the same key - should be a cache hit
+	cachedResp, found = storage.Get(key)
+	if !found {
+		t.Errorf("Expected cache hit, got cache miss")
+	}
+	if cachedResp == nil {
+		t.Errorf("Expected non-nil response, got nil")
+		return
+	}
+	if cachedResp.Inappropriate != response.Inappropriate ||
+		cachedResp.Confidence != response.Confidence ||
+		cachedResp.Reason != response.Reason {
+		t.Errorf("Expected response %v, got %v", response, cachedResp)
+	}
+}
+
+func TestStorage_ExpiredEntry(t *testing.T) {
+	// Create a new storage with 1ms TTL and max size of 10
+	storage := llm.NewStorage(1*time.Millisecond, 10)
+
+	key := "test-key"
+	response := &llm.Response{
+		Inappropriate: true,
+		Confidence:    0.9,
+		Reason:        "test reason",
+	}
+
+	// Set a response
+	storage.Set(key, response)
+
+	// Wait for expiration
+	time.Sleep(2 * time.Millisecond)
+
+	// Get the key - should be expired
+	cachedResp, found := storage.Get(key)
+	if found {
+		t.Errorf("Expected cache miss due to expiration, got cache hit")
+	}
+	if cachedResp != nil {
+		t.Errorf("Expected nil response, got %v", cachedResp)
+	}
+}
+
+func TestStorage_LRU(t *testing.T) {
+	// Create a new storage with 10s TTL and max size of 2
+	storage := llm.NewStorage(10*time.Second, 2)
+
+	// Set three entries - the first one should be evicted
+	key1 := "key1"
+	key2 := "key2"
+	key3 := "key3"
+
+	response1 := &llm.Response{Inappropriate: true, Confidence: 0.9, Reason: "reason1"}
+	response2 := &llm.Response{Inappropriate: false, Confidence: 0.7, Reason: "reason2"}
+	response3 := &llm.Response{Inappropriate: true, Confidence: 0.8, Reason: "reason3"}
+
+	storage.Set(key1, response1)
+	storage.Set(key2, response2)
+	storage.Set(key3, response3)
+
+	// key1 should be evicted (LRU)
+	cachedResp, found := storage.Get(key1)
+	if found {
+		t.Errorf("Expected key1 to be evicted, got cache hit")
+	}
+	if cachedResp != nil {
+		t.Errorf("Expected nil response, got %v", cachedResp)
+	}
+
+	// key2 and key3 should still be there
+	cachedResp, found = storage.Get(key2)
+	if !found {
+		t.Errorf("Expected key2 to be present, got cache miss")
+	}
+	if cachedResp == nil {
+		t.Errorf("Expected non-nil response, got nil")
+	}
+
+	cachedResp, found = storage.Get(key3)
+	if !found {
+		t.Errorf("Expected key3 to be present, got cache miss")
+	}
+	if cachedResp == nil {
+		t.Errorf("Expected non-nil response, got nil")
+	}
+}
+
+func TestStorage_LRU_AccessOrder(t *testing.T) {
+	// Create a new storage with 10s TTL and max size of 2
+	storage := llm.NewStorage(10*time.Second, 2)
+
+	// Set three entries
+	key1 := "key1"
+	key2 := "key2"
+	key3 := "key3"
+
+	response1 := &llm.Response{Inappropriate: true, Confidence: 0.9, Reason: "reason1"}
+	response2 := &llm.Response{Inappropriate: false, Confidence: 0.7, Reason: "reason2"}
+	response3 := &llm.Response{Inappropriate: true, Confidence: 0.8, Reason: "reason3"}
+
+	storage.Set(key1, response1)
+	storage.Set(key2, response2)
+
+	// Access key1 - it becomes most recently used
+	storage.Get(key1)
+
+	// Add key3 - key2 should be evicted (least recently used)
+	storage.Set(key3, response3)
+
+	// key2 should be evicted, key1 and key3 should remain
+	cachedResp, found := storage.Get(key2)
+	if found {
+		t.Errorf("Expected key2 to be evicted, got cache hit")
+	}
+	if cachedResp != nil {
+		t.Errorf("Expected nil response, got %v", cachedResp)
+	}
+
+	cachedResp, found = storage.Get(key1)
+	if !found {
+		t.Errorf("Expected key1 to be present, got cache miss")
+	}
+	if cachedResp == nil {
+		t.Errorf("Expected non-nil response, got nil")
+	}
+
+	cachedResp, found = storage.Get(key3)
+	if !found {
+		t.Errorf("Expected key3 to be present, got cache miss")
+	}
+	if cachedResp == nil {
+		t.Errorf("Expected non-nil response, got nil")
+	}
+}
+
+func TestStorage_Cleanup(t *testing.T) {
+	// Create a new storage with 1ms TTL and max size of 10
+	storage := llm.NewStorage(1*time.Millisecond, 10)
+
+	key1 := "key1"
+	key2 := "key2"
+	key3 := "key3"
+
+	response1 := &llm.Response{Inappropriate: true, Confidence: 0.9, Reason: "reason1"}
+	response2 := &llm.Response{Inappropriate: false, Confidence: 0.7, Reason: "reason2"}
+	response3 := &llm.Response{Inappropriate: true, Confidence: 0.8, Reason: "reason3"}
+
+	storage.Set(key1, response1)
+	storage.Set(key2, response2)
+	storage.Set(key3, response3)
+
+	// Wait for expiration
+	time.Sleep(2 * time.Millisecond)
+
+	// Cleanup should remove all expired entries
+	storage.Cleanup()
+
+	// All entries should be gone
+	cachedResp, found := storage.Get(key1)
+	if found {
+		t.Errorf("Expected key1 to be cleaned up, got cache hit")
+	}
+	if cachedResp != nil {
+		t.Errorf("Expected nil response, got %v", cachedResp)
+	}
+
+	cachedResp, found = storage.Get(key2)
+	if found {
+		t.Errorf("Expected key2 to be cleaned up, got cache hit")
+	}
+	if cachedResp != nil {
+		t.Errorf("Expected nil response, got %v", cachedResp)
+	}
+
+	cachedResp, found = storage.Get(key3)
+	if found {
+		t.Errorf("Expected key3 to be cleaned up, got cache hit")
+	}
+	if cachedResp != nil {
+		t.Errorf("Expected nil response, got %v", cachedResp)
+	}
+}
+
+func TestStorage_MaxSizeValidation(t *testing.T) {
+	// Test with zero max size - should be handled by config validation
+	// But we should still handle it gracefully
+	storage := llm.NewStorage(10*time.Second, 0)
+
+	key := "test-key"
+	response := &llm.Response{
+		Inappropriate: true,
+		Confidence:    0.9,
+		Reason:        "test reason",
+	}
+
+	// Try to set a response - should still work (but won't evict)
+	storage.Set(key, response)
+
+	// Get the same key - should be a cache hit
+	cachedResp, found := storage.Get(key)
+	if !found {
+		t.Errorf("Expected cache hit, got cache miss")
+	}
+	if cachedResp == nil {
+		t.Errorf("Expected non-nil response, got nil")
+	}
+}
+
+func TestStorage_ConcurrentStress(_ *testing.T) {
+	storage := llm.NewStorage(10*time.Second, 100)
+
+	var wg sync.WaitGroup
+	const numGoroutines = 10
+	const numOps = 100
+
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := range numOps {
+				key := fmt.Sprintf("key-%d-%d", id, j)
+				resp := &llm.Response{Inappropriate: true, Confidence: 0.9, Reason: "test"}
+				storage.Set(key, resp)
+				storage.Get(key)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional LLM response caching with TTL and max-size controls; LRU eviction when capacity is reached.
  * Cache can be enabled/disabled via configuration.

* **Documentation**
  * Configuration guide and examples updated with cache_enabled, cache_ttl, and cache_max_size settings.

* **Tests**
  * Comprehensive tests for cache behavior, expiration, eviction and concurrent access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->