### PR TITLE
[censor] prioritize Allow action over Block

### DIFF
--- a/internal/censor/plugins/duplicate/duplicate.go
+++ b/internal/censor/plugins/duplicate/duplicate.go
@@ -100,9 +100,9 @@ func (p *Plugin) Evaluate(_ context.Context, msg plugin.Message) (plugin.Result,
 		}, nil
 	}
 
-	// Within limits, allow the message
+	// Within limits, skip to let other plugins decide
 	return plugin.Result{
-		Action: plugin.ActionAllow,
+		Action: plugin.ActionSkip,
 		Reason: "duplicate limit not exceeded",
 		Metadata: map[string]any{
 			"message_hash": messageHash,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted moderation evaluation: sequential and parallel flows now short-circuit on Allow; Block decisions are deferred and aggregated after other checks.
  * Duplicate detection updated to defer final approval decisions to other checks (duplicate occurrences now yield a skip so other plugins can decide).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->